### PR TITLE
Support for basic number formatting

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,6 +40,7 @@ class Example extends StatelessWidget {
           duration: const Duration(seconds: 2),
           curve: Curves.decelerate,
           textStyle: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold),
+          format: NumberFormatMode.comma,
         ),
       )),
     );

--- a/lib/number_slide_animation_widget.dart
+++ b/lib/number_slide_animation_widget.dart
@@ -30,11 +30,17 @@ class NumberSlideAnimation extends StatefulWidget {
   /// defaults to: Curves.easeIn
   final Curve curve;
 
+  /// The formatting style the number will be displayed in
+  ///
+  /// default to: NumberFormat.none
+  final NumberFormatMode format;
+
   NumberSlideAnimation(
       {@required this.number,
       this.textStyle = const TextStyle(fontSize: 16.0),
       this.duration = const Duration(milliseconds: 1500),
-      this.curve = Curves.easeIn})
+      this.curve = Curves.easeIn,
+      this.format = NumberFormatMode.none})
       : assert(int.tryParse(number) != null);
 
   @override
@@ -65,19 +71,57 @@ class _NumberSlideAnimationState extends State<NumberSlideAnimation> {
     return box.size;
   }
 
+  isNumeric(String string) => num.tryParse(string) != null;
+
+  String getFormattedNumber(String number, NumberFormatMode mode) {
+    if (mode == NumberFormatMode.none) return number;
+
+    final String separator = mode == NumberFormatMode.period ? '.' : ',';
+    return number.replaceAllMapped(
+      new RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+      (Match m) => '${m[1]}$separator',
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final formattedNumber = getFormattedNumber(widget.number, widget.format);
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       key: _rowKey,
-      children: List.generate(widget.number.length, (position) {
-        return NumberCol(
-          animateTo: int.parse(widget.number[position]),
-          textStyle: widget.textStyle,
-          duration: widget.duration,
-          curve: widget.curve,
-        );
+      children: List.generate(formattedNumber.length, (position) {
+        final digit = formattedNumber[position];
+
+        if (isNumeric(digit)) {
+          return NumberCol(
+            animateTo: int.parse(digit),
+            textStyle: widget.textStyle,
+            duration: widget.duration,
+            curve: widget.curve,
+          );
+        }
+
+        return Text(digit, style: widget.textStyle);
       }),
     );
   }
+}
+
+/// Defines the type of formatting used for the number.
+///
+/// [none] does not enforce any formatting and will output the number as given.
+///
+/// [comma] uses "," as the thousand separator e.g. 1,234
+///
+/// [period] uses "." as the thousand separator e.g. 1.234
+enum NumberFormatMode {
+  /// No number formatting is used e.g. 1234
+  none,
+
+  /// "," will be used as the "thousand" separators e.g. 1,234
+  comma,
+
+  /// "." will be used as the "thousand" separators e.g. 1.234
+  period,
 }


### PR DESCRIPTION
Addresses issue #2. 

Please note this is only addresses integer number formatting and does not support formatting for numbers with decimals.

I updated the example so you can quickly see the new output, but let me know and I can revert!