### PR TITLE
Migrated null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.0] - 2021-03-07
+
+* Migrated to null safety
+
 ## [0.1.1] - 2019-09-08
 
 * Added some more description to README

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/nils/fvm/versions/stable"
+export "FLUTTER_APPLICATION_PATH=/Users/nils/Desktop/Projekte/number_slide_animation/example"
+export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "DART_OBFUSCATION=false"
+export "TRACK_WIDGET_CREATION=false"
+export "TREE_SHAKE_ICONS=false"
+export "PACKAGE_CONFIG=.packages"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.2.0"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,28 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -36,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -52,42 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   number_slide_animation:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.7.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.3"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,55 +106,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,6 +16,8 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.1.0 <3.0.0"
 
+publish_to: none
+
 dependencies:
   flutter:
     sdk: flutter

--- a/lib/number_slide_animation.dart
+++ b/lib/number_slide_animation.dart
@@ -1,3 +1,3 @@
 library number_slide_animation;
 
-export 'number_slide_animation_widget.dart';
+export 'src/number_slide_animation_widget.dart';

--- a/lib/src/number_col.dart
+++ b/lib/src/number_col.dart
@@ -13,12 +13,12 @@ class NumberCol extends StatefulWidget {
   // The curve that is used during the animation
   final Curve curve;
 
-  NumberCol(
-      {@required this.animateTo,
-      @required this.textStyle,
-      @required this.duration,
-      @required this.curve})
-      : assert(animateTo != null && animateTo >= 0 && animateTo < 10);
+  NumberCol({
+    required this.animateTo,
+    required this.textStyle,
+    required this.duration,
+    required this.curve,
+  }) : assert(animateTo >= 0 && animateTo < 10);
 
   @override
   _NumberColState createState() => _NumberColState();
@@ -26,7 +26,7 @@ class NumberCol extends StatefulWidget {
 
 class _NumberColState extends State<NumberCol>
     with SingleTickerProviderStateMixin {
-  ScrollController _scrollController;
+  ScrollController? _scrollController;
 
   double _elementSize = 0.0;
 
@@ -36,11 +36,11 @@ class _NumberColState extends State<NumberCol>
 
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _elementSize = _scrollController.position.maxScrollExtent / 10;
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      _elementSize = _scrollController!.position.maxScrollExtent / 10;
       setState(() {});
 
-      _scrollController.animateTo(_elementSize * widget.animateTo,
+      _scrollController!.animateTo(_elementSize * widget.animateTo,
           duration: widget.duration, curve: widget.curve);
     });
   }

--- a/lib/src/number_slide_animation_widget.dart
+++ b/lib/src/number_slide_animation_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'number_col.dart';
+import 'src/../number_col.dart';
 
 /// This widget will display the provided [number] given in the constructor
 ///
@@ -30,12 +30,12 @@ class NumberSlideAnimation extends StatefulWidget {
   /// defaults to: Curves.easeIn
   final Curve curve;
 
-  NumberSlideAnimation(
-      {@required this.number,
-      this.textStyle = const TextStyle(fontSize: 16.0),
-      this.duration = const Duration(milliseconds: 1500),
-      this.curve = Curves.easeIn})
-      : assert(int.tryParse(number) != null);
+  NumberSlideAnimation({
+    required this.number,
+    this.textStyle = const TextStyle(fontSize: 16.0),
+    this.duration = const Duration(milliseconds: 1500),
+    this.curve = Curves.easeIn,
+  }) : assert(int.tryParse(number) != null);
 
   @override
   _NumberSlideAnimationState createState() => _NumberSlideAnimationState();
@@ -44,13 +44,13 @@ class NumberSlideAnimation extends StatefulWidget {
 class _NumberSlideAnimationState extends State<NumberSlideAnimation> {
   double _width = 1000.0;
 
-  GlobalKey _rowKey = new GlobalKey();
+  GlobalKey _rowKey = GlobalKey();
 
   @override
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
       print(getRowSize().width.toString());
       setState(() {
         _width = getRowSize().width;
@@ -61,7 +61,8 @@ class _NumberSlideAnimationState extends State<NumberSlideAnimation> {
   }
 
   Size getRowSize() {
-    final RenderBox box = _rowKey.currentContext.findRenderObject();
+    final RenderBox box =
+        _rowKey.currentContext!.findRenderObject() as RenderBox;
     return box.size;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,28 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -45,35 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.7.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.3"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -85,55 +92,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: number_slide_animation
 description: A Number that will be displayed with a neat animation
-version: 0.1.1
+version: 0.2.0
 author: Justin Vietz
 homepage: https://github.com/kiesman99/number_slide_animation
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Justin Vietz
 homepage: https://github.com/kiesman99/number_slide_animation
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/test/number_col_test.dart
+++ b/test/number_col_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
-import 'package:number_slide_animation/number_col.dart';
+import 'package:number_slide_animation/src/number_col.dart';
 
 void main() {
   test('try initializing with invalid number', () {


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to `2.12.0+`
* Run `dart migrate` on existing code to remove unsafe nulls (for the package & example)
* Add a new version (`0.2.0`) to the changelog (as [recommended](https://dart.dev/null-safety/migration-guide#package-version))
* Moved `number_col.dart ` and `number_slide_animation_widget.dart` in `lib/src` 

Please check everything twice!

## Testing
- [x] All existing tests are passing
- [x] Tested it manually on a Android emulator 

### Related tickets
Closes #9 