### PR TITLE
Fix analyzer warning when build an app with this package using Flutter +3.0

### DIFF
--- a/lib/src/number_col.dart
+++ b/lib/src/number_col.dart
@@ -36,7 +36,7 @@ class _NumberColState extends State<NumberCol>
 
     super.initState();
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       _elementSize = _scrollController!.position.maxScrollExtent / 10;
       setState(() {});
 

--- a/lib/src/number_slide_animation_widget.dart
+++ b/lib/src/number_slide_animation_widget.dart
@@ -50,7 +50,7 @@ class _NumberSlideAnimationState extends State<NumberSlideAnimation> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       print(getRowSize().width.toString());
       setState(() {
         _width = getRowSize().width;


### PR DESCRIPTION
Removes the warning that you get when building the app:

```
/opt/hostedtoolcache/flutter/3.13.0-stable/x64/.pub-cache/hosted/pub.dev/number_slide_animation-0.2.1/lib/src/number_slide_animation_widget.dart:53:20:
Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/opt/hostedtoolcache/flutter/3.13.0-stable/x64/packages/flutter/lib/src/widgets/binding.dart').
    WidgetsBinding.instance!.addPostFrameCallback((_) ***
                   ^
/opt/hostedtoolcache/flutter/3.13.0-stable/x64/.pub-cache/hosted/pub.dev/number_slide_animation-0.2.1/lib/src/number_col.dart:39:20:
Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('/opt/hostedtoolcache/flutter/3.13.0-stable/x64/packages/flutter/lib/src/widgets/binding.dart').
    WidgetsBinding.instance!.addPostFrameCallback((_) ***
```