### PR TITLE
fixed this state update problem

### DIFF
--- a/lib/src/number_col.dart
+++ b/lib/src/number_col.dart
@@ -38,11 +38,30 @@ class _NumberColState extends State<NumberCol>
 
     WidgetsBinding.instance!.addPostFrameCallback((_) {
       _elementSize = _scrollController!.position.maxScrollExtent / 10;
-      setState(() {});
-
-      _scrollController!.animateTo(_elementSize * widget.animateTo,
-          duration: widget.duration, curve: widget.curve);
+      _calculateElementSizeAndAnimate();
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant NumberCol oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.animateTo != oldWidget.animateTo) {
+      _calculateElementSizeAndAnimate();
+    }
+  }
+
+  void _calculateElementSizeAndAnimate() {
+    setState(() {});
+
+    // Animate to the selected number
+    _scrollController!.animateTo(
+      _elementSize * widget.animateTo,
+      duration: widget.duration,
+      curve: widget.curve,
+    );
+
+    _scrollController!.animateTo(_elementSize * widget.animateTo,
+        duration: widget.duration, curve: widget.curve);
   }
 
   @override


### PR DESCRIPTION
i had a problem the widget doesnt update its state unless the length of the number changes, and not even update the whole number no, it updates only the last position, i made the widget recalculate the scroll position everytime the number changes 